### PR TITLE
학생 강의 접속 토큰 구현

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -8,21 +8,27 @@ import { ConfigService } from '@nestjs/config';
 
 describe('AuthController', () => {
   let controller: AuthController;
-  let authService: AuthService;
+  let authService;
 
-  const mockAuthService = {
-    logIn: jest.fn(),
-  };
-  const mockConfigService = {
-    get: jest.fn().mockImplementation((key: string) => {
-      const config = {
-        JWT_EXPIRATION: '4h',
-        JWT_REFRESH_EXPIRATION: '7d',
-      };
-      return config[key];
-    }),
-  };
+  let mockAuthService;
+  let mockConfigService;
+
   beforeEach(async () => {
+    mockAuthService = {
+      logIn: jest.fn().mockResolvedValue({
+        instructorId: 'tester',
+        access_token: 'mockAccessToken',
+      }),
+    };
+    mockConfigService = {
+      get: jest.fn().mockImplementation((key: string) => {
+        const config = {
+          JWT_EXPIRATION: '4h',
+          JWT_REFRESH_EXPIRATION: '7d',
+        };
+        return config[key];
+      }),
+    };
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
       providers: [
@@ -52,10 +58,6 @@ describe('AuthController', () => {
         password: 'password',
       };
 
-      mockAuthService.logIn.mockResolvedValueOnce({
-        instructorId: 'tester',
-        accessToken: 'mockAccessToken',
-      });
       const res = mockResponse();
 
       const result = await controller.logIn(loginDto, res);
@@ -63,7 +65,7 @@ describe('AuthController', () => {
       expect(mockAuthService.logIn).toHaveBeenCalledWith(loginDto, res);
       expect(result).toEqual({
         instructorId: 'tester',
-        accessToken: 'mockAccessToken',
+        access_token: 'mockAccessToken',
       });
     });
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -28,7 +28,6 @@ export class AuthController {
   @ApiBody({ type: LoginDto, description: '로그인 데이터 (ID와 비밀번호)' })
   async logIn(@Body() logInDto: LoginDto, @Res() res: Response) {
     const result = await this.authService.logIn(logInDto, res);
-
     res.json(result);
     return result;
   }

--- a/src/auth/auth.jwt-auth.guard.ts
+++ b/src/auth/auth.jwt-auth.guard.ts
@@ -9,17 +9,14 @@ export class JwtAuthGuard extends AuthGuard('jwt') implements CanActivate {
   }
 
   canActivate(context: ExecutionContext): boolean {
-    console.log('AuthGuard Triggered');
     const isPublic = this.reflector.get<boolean>(
       'isPublic',
       context.getHandler(),
     );
-    console.log('Is Public Route:', isPublic);
     if (isPublic) {
       return true; // 인증 제외
     }
     const request = context.switchToHttp().getRequest();
-    console.log('Authorization Header:', request.headers.authorization);
     return super.canActivate(context) as boolean;
   }
 }

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -5,6 +5,7 @@ import { JwtService } from '@nestjs/jwt';
 import { UnauthorizedException } from '@nestjs/common';
 import { mockResponse } from '../test-utils/mockResponse';
 import { ConfigService } from '@nestjs/config';
+import { mockJwtService } from '../test-utils/mockJwtService';
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -16,11 +17,6 @@ describe('AuthService', () => {
       }
       return null;
     }),
-  };
-
-  const mockJwtService = {
-    sign: jest.fn().mockReturnValue('mockAccessToken'),
-    verify: jest.fn(),
   };
 
   const mockConfigService = {

--- a/src/lecture/lecture.controller.spec.ts
+++ b/src/lecture/lecture.controller.spec.ts
@@ -11,7 +11,7 @@ describe('LectureController', () => {
 
   beforeEach(async () => {
     mockLectureService = {
-      create: jest.fn().mockResolvedValue('00000'),
+      create: jest.fn().mockResolvedValue({ lectureId: 1, code: '00000' }),
       update: jest.fn().mockResolvedValue({ id: 1 }),
       getOne: jest.fn().mockResolvedValue({
         instructorId: 'test',
@@ -45,7 +45,10 @@ describe('LectureController', () => {
       const result = await controller.create(createDto);
 
       expect(mockLectureService.create).toHaveBeenCalledWith(createDto);
-      expect(result).toBe('00000');
+      expect(result).toEqual({
+        lectureId: 1,
+        code: '00000',
+      });
     });
   });
   describe('update', () => {

--- a/src/lecture/lecture.service.ts
+++ b/src/lecture/lecture.service.ts
@@ -20,7 +20,9 @@ export class LectureService {
     return { code };
   }
 
-  async create(createDto: LectureCreateDto): Promise<{ code: string }> {
+  async create(
+    createDto: LectureCreateDto,
+  ): Promise<{ lectureId: number; code: string }> {
     const { instructorId, code } = createDto;
     const instructor = await this.instructorService.getOne(instructorId);
     if (!instructor) {
@@ -38,7 +40,7 @@ export class LectureService {
       where: { id: lectureId },
     });
     if (result) {
-      return { code: result.code };
+      return { lectureId, code: result.code };
     }
   }
 

--- a/src/student/student.controller.spec.ts
+++ b/src/student/student.controller.spec.ts
@@ -4,19 +4,12 @@ import { StudentConnectDto } from './dto/studnet.dto';
 import { Lecture } from '../lecture/entities/lecture.entitiy';
 import { StudentService } from './student.service';
 import { NotFoundException } from '@nestjs/common';
+import { mockResponse } from '../test-utils/mockResponse';
 
 describe('StudentsController', () => {
   let controller: StudentController;
   let mockStudentService;
 
-  const lecture = {
-    id: 1,
-    code: '00000',
-    active: true,
-    created_at: new Date(),
-    updated_at: new Date(),
-    instructor: { id: 1, userid: 'test' },
-  } as Lecture;
   beforeEach(async () => {
     mockStudentService = {
       connect: jest.fn().mockResolvedValue({
@@ -24,6 +17,7 @@ describe('StudentsController', () => {
         name: 'test',
         lecture_id: 1,
         joined_at: expect.any(Date),
+        access_token: 'mockAccessToken',
       }),
     };
     const module: TestingModule = await Test.createTestingModule({
@@ -46,15 +40,17 @@ describe('StudentsController', () => {
   describe('lecture-connect', () => {
     it('should connect a student to a lecture', async () => {
       const connectDto: StudentConnectDto = { name: 'test', code: '00000' };
+      const res = mockResponse();
 
-      const result = await controller.connect(connectDto);
+      const result = await controller.connect(connectDto, res);
 
-      expect(mockStudentService.connect).toHaveBeenCalledWith(connectDto);
+      expect(mockStudentService.connect).toHaveBeenCalledWith(connectDto, res);
       expect(result).toEqual({
         id: 1,
         name: 'test',
         lecture_id: 1,
         joined_at: expect.any(Date),
+        access_token: 'mockAccessToken',
       });
     });
 
@@ -67,8 +63,9 @@ describe('StudentsController', () => {
       mockStudentService.connect.mockRejectedValue(() => {
         throw new NotFoundException('Lecture not found');
       });
+      const res = mockResponse();
 
-      await expect(controller.connect(connectDto)).rejects.toThrow(
+      await expect(controller.connect(connectDto, res)).rejects.toThrow(
         NotFoundException,
       );
     });

--- a/src/student/student.controller.ts
+++ b/src/student/student.controller.ts
@@ -1,7 +1,16 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Res,
+  SetMetadata,
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { StudentService } from './student.service';
 import { StudentConnectDto } from './dto/studnet.dto';
+import { Response } from 'express';
 
 @ApiTags('Student')
 @ApiBearerAuth('access-token')
@@ -11,6 +20,7 @@ export class StudentController {
 
   @HttpCode(HttpStatus.OK)
   @Post('/lecture_connect')
+  @SetMetadata('isPublic', true)
   @ApiOperation({
     summary: '강의 접속',
     description:
@@ -21,7 +31,9 @@ export class StudentController {
     type: StudentConnectDto,
     description: '강의 연결에 필요한 데이터를 입력합니다.',
   })
-  connect(@Body() connectDto: StudentConnectDto) {
-    return this.studentService.connect(connectDto);
+  async connect(@Body() connectDto: StudentConnectDto, @Res() res: Response) {
+    const result = await this.studentService.connect(connectDto, res);
+    res.json(result);
+    return result;
   }
 }

--- a/src/student/student.module.ts
+++ b/src/student/student.module.ts
@@ -4,9 +4,10 @@ import { StudentController } from './student.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Student } from './entities/student.entity';
 import { LectureModule } from '../lecture/lecture.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Student]), LectureModule],
+  imports: [TypeOrmModule.forFeature([Student]), LectureModule, AuthModule],
   providers: [StudentService],
   controllers: [StudentController],
   exports: [StudentService],

--- a/src/test-utils/mockJwtService.ts
+++ b/src/test-utils/mockJwtService.ts
@@ -1,0 +1,9 @@
+export const mockJwtService = {
+  sign: jest.fn().mockReturnValue('mockAccessToken'),
+  verify: jest.fn().mockImplementation((token) => {
+    if (token === 'validRefreshToken') {
+      return { userid: 'tester', sub: 1 };
+    }
+    throw new Error('Invalid token');
+  }),
+};


### PR DESCRIPTION
- 학생이 강의 접속 시 JWT 토큰 발급
  - studentLogin() 메서드를 AuthService에 추가하여 학생이 접속 시 JWT를 발급받도록 구현
  - 학생의 이름(name)과 강의 코드(code) 로 강의에 접속 후, 학생 ID와 강의 ID를 포함한 토큰 발급
  - refreshToken도 발급하여 세션을 유지할 수 있도록 구현

- 학생 서비스(StudentService)에서 AuthService와 연동
  - StudentService에서 강의 접속 시, AuthService.studentLogin()을 호출하여 토큰을 생성 후 반환

- student.controller.ts 수정
  - lecture_connect API 응답에 access_token 포함
  - 기존 StudentConnectResponseDto에 access_token을 추가하여, 프론트엔드에서 해당 토큰을 활용할 수 있도록 변경

- 테스트 코드 업데이트
  - mockAuthService 추가하여 studentLogin()을 jest.fn()으로 모킹
  - mockResponse() 개선하여 res.json()의 반환값을 테스트 가능하도록 수정
  - StudentController, StudentService의 유닛 테스트 수정하여 JWT 발급을 검증