### PR TITLE
강의 조회 jwt 제외 설정

### DIFF
--- a/src/lecture/lecture.controller.ts
+++ b/src/lecture/lecture.controller.ts
@@ -7,6 +7,7 @@ import {
   Post,
   Put,
   Query,
+  SetMetadata,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -66,6 +67,7 @@ export class LectureController {
 
   @HttpCode(HttpStatus.OK)
   @Get()
+  @SetMetadata('isPublic', true)
   @ApiOperation({
     summary: '강의 조회',
     description:

--- a/src/student/student.service.ts
+++ b/src/student/student.service.ts
@@ -37,7 +37,7 @@ export class StudentService {
       where: { name, lecture: { id: lectureId } },
     });
 
-    return !existingStudent;
+    return !!existingStudent;
   }
   async connect(
     connectDto: StudentConnectDto,
@@ -49,7 +49,7 @@ export class StudentService {
       throw new NotFoundException('Lecture not exists');
     }
     const isNameUnique = await this.checkName(name, lecture.id);
-    if (!isNameUnique) {
+    if (isNameUnique) {
       throw new BadRequestException('Name already exists in the lecture');
     }
     const insertedStudent = await this.studentRepository.save({


### PR DESCRIPTION
- 강의 조회 API(/lecture?code=...)에 대해 JWT 인증을 제외함.
- 인증이 필요한 엔드포인트는 유지하면서, 강의 조회만 공개 접근 가능하도록 변경.
- 보안 고려 사항을 검토하여 강의 코드 외의 추가 정보를 최소한으로 반환하도록 조정.